### PR TITLE
Criando o maratona-editores-chile.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -31,3 +31,10 @@ Description: Pacote Virtual do Maratona Linux com os editores permitidos
  .
  É um pacote seguro para se instalar em qualquer ambiente Ubuntu e Debian.
 
+Package: maratona-editores-chile
+Architecture: all
+Pre-Depends: snapd
+Description: Pacote contendo a instalação do sublime-text para o maratona
+ via snap.
+ .
+ É um pacote seguro para se instalar em qualquer ambiente Ubuntu e Debian.

--- a/debian/maratona-editores-chile.postinst
+++ b/debian/maratona-editores-chile.postinst
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e
+. /usr/share/debconf/confmodule
+# Function which try install a program of Snap in 3 tries.
+# Defaults of requisition:
+#   $1 - Name of package
+#   $2 - Arg1 of snap (--classic or --edge)
+#   $3 - Arg2 of snap (--classic or --edge)
+
+try_install_snap() {
+	try=0
+	while [ $(snap list | grep $1 | wc -l) -eq 0 ] && [ $try -lt 3 ]; do
+		snap install $1 $2 $3
+	    try=$((try+1))
+	done
+
+	# In case of success, return 0. In case of failure, return 1.
+	if [ $(snap list | grep $1 | wc -l) -eq 0 ]; then
+		return 1
+	else
+		return 0
+	fi
+}
+
+flag=1
+while [ $flag -eq 1 ]; do
+	packages=""
+	try_install_snap sublime-text --classic || packages=$packages"sublime-text"
+
+	if [ "$packages" != "" ]; then
+		db_subst maratona-editores-chile/question_try_again package $packages || true
+		db_input high maratona-editores-chile/question_try_again || true
+		db_go || true
+		db_get maratona-editores-chile/question_try_again || true
+		if [ "$RET" == "Later" ]; then
+			flag=0
+			db_input high maratona-editores-chile/notice || true
+			db_go || true
+			db_get maratona-editores-chile/notice
+		fi
+	else
+		flag=0
+	fi
+done
+

--- a/debian/maratona-editores-chile.templates
+++ b/debian/maratona-editores-chile.templates
@@ -1,0 +1,11 @@
+Template: maratona-editores-chile/question_try_again
+Type: select
+Choices: Try Again, Later
+Description: It was not possible to install the package(s) ${package} via snap.
+ Do you want to try to install again?
+
+Template: maratona-editores-chile/notice
+Type: note
+Description: Please, try again another time with:
+ sudo dpkg-reconfigure maratona-editores
+


### PR DESCRIPTION
d/control: Criado o pacote maratona-editores-chile. Esse pacote tem como
objetivo instalar o sublime-text via snap.

d/maratona-editores-chile.postinst: Copia do postinst do maratona-editores com a
diferença que o unico pacote snap a ser instalado é o sublime-text.

d/maratona-editores-chile.templates: Copia do template do maratona-editores com
a diferença que é feita as adaptações para funcionar com o
maratona-editores-chile.

Signed-off-by: wallberg13 <wallbergmirandamorais@gmail.com>