### PR TITLE
Adicionado ao maratona-editores o plugin eclipse-cdt, do eclipse.

### DIFF
--- a/debian/maratona-editores.postinst
+++ b/debian/maratona-editores.postinst
@@ -47,8 +47,3 @@ while [ $flag -eq 1 ]; do
 		flag=0
 	fi
 done
-
-# Adicionando o plugin do Eclipse - Descompactando o arquivo.
-[ -f /etc/skel/eclipse-cdt.tar.xz ] && \
-tar -xf /etc/skel/eclipse-cdt.tar.xz -C /etc/skel/ && \
-rm /etc/skel/eclipse-cdt.tar.xz

--- a/debian/maratona-editores.postinst
+++ b/debian/maratona-editores.postinst
@@ -48,3 +48,7 @@ while [ $flag -eq 1 ]; do
 	fi
 done
 
+# Adicionando o plugin do Eclipse - Descompactando o arquivo.
+[ -f /etc/skel/eclipse-cdt.tar.xz ] && \
+tar -xf /etc/skel/eclipse-cdt.tar.xz -C /etc/skel/ && \
+rm /etc/skel/eclipse-cdt.tar.xz

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,10 @@
 #! /usr/bin/make -f
 
 override_dh_auto_install:
+	# Plugin Eclipse-cdt
+	mkdir -p debian/maratona-editores/etc/skel/
+	cp plugins/* debian/maratona-editores/etc/skel/
+
 	# Icones na pasta destinada a icones no /usr/share/icons
 	mkdir -p debian/maratona-linguagens-doc/usr/share/icons/maratona-linguagens-doc/scalable/
 	cp icons/* debian/maratona-linguagens-doc/usr/share/icons/maratona-linguagens-doc/scalable/

--- a/debian/rules
+++ b/debian/rules
@@ -3,7 +3,7 @@
 override_dh_auto_install:
 	# Plugin Eclipse-cdt
 	mkdir -p debian/maratona-editores/etc/skel/
-	cp plugins/* debian/maratona-editores/etc/skel/
+	tar -xf plugins/eclipse-cdt.tar.xz -C debian/maratona-editores/etc/skel/
 
 	# Icones na pasta destinada a icones no /usr/share/icons
 	mkdir -p debian/maratona-linguagens-doc/usr/share/icons/maratona-linguagens-doc/scalable/


### PR DESCRIPTION
plugins/eclipse-cdt.tar.xz: Arquivo que deve ser adicionado no /etc/skel do
ambiente do maratona, para que na criação do usuário icpc o plugin eclipse-cdt
possa está disponível para o usuário.

d/rules: Copiando o arquivo eclipse-cdt.tar.xz para a pasta /etc/skel

d/maratona-editores.postinst: Adicionado ao script a parte referente ao
eclipse-cdt, que é de descompactar o arquivo no /etc/skel.

Signed-off-by: Wall Berg Morais <wallbergmirandamorais@gmail.com>