### PR TITLE
Adicionado ao maratona-team-tools o maratona-editores-cuba.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -42,8 +42,9 @@ Description: Pacote contendo a instalação do sublime-text para o maratona
 
 Package: maratona-editores-cuba
 Architecture: all
+Pre-Depends: wget
 Depends: default-jdk, default-jre
 Description: Pacote contendo a instalação do netbeans apache para o maratona
- via snap.
+ via wget.
  .
  É um pacote seguro para se instalar em qualquer ambiente Ubuntu e Debian.

--- a/debian/control
+++ b/debian/control
@@ -39,3 +39,11 @@ Description: Pacote contendo a instalação do sublime-text para o maratona
  via snap.
  .
  É um pacote seguro para se instalar em qualquer ambiente Ubuntu e Debian.
+
+Package: maratona-editores-cuba
+Architecture: all
+Depends: default-jdk, default-jre
+Description: Pacote contendo a instalação do netbeans apache para o maratona
+ via snap.
+ .
+ É um pacote seguro para se instalar em qualquer ambiente Ubuntu e Debian.

--- a/debian/maratona-editores-cuba.postinst
+++ b/debian/maratona-editores-cuba.postinst
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -e
+
+# --------- Inicio da instalação do NetBeans ---------
+# Verifica se o netbeans existe, caso positivo, exclui ele.
+[ -d /opt/netbeans ] && rm -Rf /opt/netbeans
+[ -f /usr/bin/netbeans ] && rm -Rf /usr/bin/netbeans
+[ -f /usr/share/applications/netbeans.desktop ] && \
+	rm -Rf /usr/share/applications/netbeans.desktop
+
+# Baixando o netbeans do repositorio.
+wget http://ftp.unicamp.br/pub/apache/incubator/netbeans/incubating-netbeans-java/incubating-9.0/incubating-netbeans-java-9.0-bin.zip -O /tmp/netbeans.zip
+
+RET=$?
+if [[ "$RET" != "0" ]] ; then
+	exit $RET
+fi
+
+# Descompactando
+[ -f /tmp/netbeans.zip ] && unzip -q /tmp/netbeans.zip -d /opt/
+
+# Fazendo um link para /usr/bin/netbeans, para que todos os usuários vejam.
+[ -d /opt/netbeans ] && ln -sf /opt/netbeans/bin/netbeans /usr/bin/netbeans
+
+# Adicionando atalho para /usr/share/applications/
+[ -d /opt/netbeans ] && cat << EOF > /usr/share/applications/netbeans.desktop
+[Desktop Entry]
+Version=1.0
+Name=netbeans
+Exec=/opt/netbeans/bin/netbeans
+Icon=/opt/netbeans/nb/netbeans.png
+Type=Application
+Categories=Application
+EOF
+# ------- Fim da intalação do NetBeans -------
+
+exit 0

--- a/debian/maratona-editores-cuba.postrm
+++ b/debian/maratona-editores-cuba.postrm
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+# Removendo o netbeans da máquina.
+[ -d /opt/netbeans ] && rm -Rf /opt/netbeans
+[ -f /usr/bin/netbeans ] && rm -Rf /usr/bin/netbeans
+[ -f /usr/share/applications/netbeans.desktop ] && \
+	rm -Rf /usr/share/applications/netbeans.desktop
+
+exit 0


### PR DESCRIPTION
d/control: Adicionado o pacote maratona-editores-cuba, que fará a instalação do
Apache Netbeans 9. Esse pacote possui como dependência somente o default-jdk e o
default-jre, pois sem esses dois pacotes, o netbeans não funciona. Essa
instalação é feita via wget.

d/maratona-editores-cuba.postinst: Adicionado script de pós instalação, que na
verdade irá fazer a instalação do netbeans. Primeiramente, esse script
irá remover uma possivél versão do netbeans excluindo os seus arquivos que
geralmente ficam em /opt/netbeans, /usr/bin/netbeans e
/usr/share/applications/netbeans.desktop. Logo depois, será feito um wget do
.zip no qual os arquivos do netbeans estão presentes. Logo depois, esse .zip é
extraído para a pasta do /opt/netbeans, como também é gerado um atalho e é
gerado um link simbólico entre /opt/netbeans/bin/netbeans e
/usr/bin/netbeans.

d/maratona-editores-cuba.postrm: Adicionando script que irá remover o netbeans
da máquina do usuário, que básicamente é a mesma coisa que acontece no começo do
script de instalação do pacote.

Signed-off-by: Wall Berg Morais <wallbergmirandamorais@gmail.com>