### PR TITLE
Fix installation of vscode cpp extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ debian/maratona-linguagens.postrm.debhelper
 debian/maratona-linguagens/
 debian/maratona-vscode-extensions.postrm.debhelper
 debian/maratona-vscode-extensions/
+*.swp

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,42 @@
+maratona-team-tools (20210517) focal; urgency=medium
+
+  [ Guilherme Banci ]
+  * maratona-linguagens depends on maratona-snap-common
+  * removing maratona-editores-chile and creating maratona-editores-snap
+  * removing vim-gnome and gedit-developer-plugins
+  * adding Clion to maratona-editores-snap
+
+  [ Guilherme Deusdará ]
+  * updating maratona-editores-snap description
+  * creating maratona-vscode-extensions
+  * installing kotlin from url
+  * switching from snapd to flatpak
+  * removing deprecated python2
+  * adding wget to maratona-linguagens dependencies
+  * maratona-vscode-extensions Enhances maratona-editores-flatpak
+
+  [ Bruno Ribas ]
+  * d/control remove trailing spaces
+  * Partial fix to `maratona-vscode-extensions` dependencies
+
+  [ Guilherme Deusdará ]
+  * Update Python3 Doc URI  (#24)
+  * Removing libstdc++ Dependencies (#17) (#25)
+  * creating maratona-kotlin-doc package (#26)
+
+  [ Guilherme Banci ]
+  * fixing kotlin icon
+
+  [ Davi Antônio da Silva Santos ]
+  * Update .gitignore
+  * Bump compat from 9 to 12
+  * Remove sublime and eclipse
+  * Add vim swap files to .gitignore
+  * Fix required download for C/C++ extension
+  * Improve maintainability with locals and arrays
+
+ -- Davi Antônio da Silva Santos <antoniossdavi@gmail.com>  Mon, 17 May 2021 20:12:36 -0300
+
 maratona-team-tools (20190716.1) bionic; urgency=low
 
   * Removed eclipse-cdt plugin

--- a/debian/control
+++ b/debian/control
@@ -42,7 +42,7 @@ Package: maratona-vscode-extensions
 Architecture: all
 Enhances: maratona-editores-flatpak
 Pre-depends: maratona-editores-flatpak
-Depends: debconf
+Depends: debconf, jq, wget
 Description: Pacote contendo a instalação das extenções do vscode necessarias para a maratona.
  .
  É um pacote seguro para se instalar em qualquer ambiente Ubuntu e Debian.

--- a/debian/maratona-vscode-extensions.postinst
+++ b/debian/maratona-vscode-extensions.postinst
@@ -1,17 +1,18 @@
 #!/bin/bash
 set -e
-source /usr/share/debconf/confmodule
+source '/usr/share/debconf/confmodule'
 
 try_install_extension() {
-	options="--extensions-dir /opt/vscode-extensions/ --user-data-dir /opt/vscode-extensions/"
-	try=0
-	while ! flatpak run com.visualstudio.code --list-extensions $options | grep -q $1 && [ $try -lt 3 ]; do
-		flatpak run com.visualstudio.code --install-extension $1 $options
-	  try=$((try+1))
+	local -r options=(--extensions-dir '/opt/vscode-extensions/' --user-data-dir '/opt/vscode-extensions/')
+	local try=0
+
+	while ! flatpak run com.visualstudio.code "${options[@]}" --list-extensions | grep -q "$1" && [ "$try" -lt 3 ]; do
+		flatpak run com.visualstudio.code "${options[@]}" --install-extension "$1"
+		try=$((try+1))
 	done
 
 	# In case of success, return 0. In case of failure, return 1.
-	if ! flatpak run com.visualstudio.code --list-extensions $options | grep -q $1 ; then
+	if ! flatpak run com.visualstudio.code "${options[@]}" --list-extensions | grep -q "$1" ; then
 		return 1
 	else
 		return 0
@@ -19,10 +20,11 @@ try_install_extension() {
 }
 
 install_cpptools_extension() {
-	readonly releases_url="https://api.github.com/repos/microsoft/vscode-cpptools/releases/latest"
-	readonly releases_info_file="releases.json"
-	download_url=""
-	readonly package_file="cpptools-linux.vsix"
+	local -r releases_url='https://api.github.com/repos/microsoft/vscode-cpptools/releases/latest'
+	local -r releases_info_file='releases.json'
+	local download_url=""
+	local -r package_file='cpptools-linux.vsix'
+	local -r options=(--extensions-dir '/opt/vscode-extensions/' --user-data-dir '/opt/vscode-extensions/')
 
 	echo "Accessing $releases_url"
 
@@ -55,7 +57,7 @@ install_cpptools_extension() {
 	fi
 
 	# install
-	if ! flatpak run com.visualstudio.code --extensions-dir /opt/vscode-extensions/ --user-data-dir /opt/vscode-extensions/ --install-extension "$package_file" ; then
+	if ! flatpak run com.visualstudio.code "${options[@]}" --install-extension "$package_file" ; then
 		echo "Failed to install ms-vscode.cpptools"
 		return 6
 	fi
@@ -70,31 +72,31 @@ while $flag ; do
 	extensions=""
 
 	extensions_list=(
-		austin.code-gnu-global
-		formulahendry.code-runner
-		vscjava.vscode-java-debug
-		vscjava.vscode-java-dependency
-		vscjava.vscode-java-pack
-		vscjava.vscode-java-test
-		redhat.java
-		vscjava.vscode-maven
-		ms-python.python
-  )
+		'austin.code-gnu-global'
+		'formulahendry.code-runner'
+		'vscjava.vscode-java-debug'
+		'vscjava.vscode-java-dependency'
+		'vscjava.vscode-java-pack'
+		'vscjava.vscode-java-test'
+		'redhat.java'
+		'vscjava.vscode-maven'
+		'ms-python.python'
+	)
 
 	for extension in "${extensions_list[@]}"
 	do
-		try_install_extension $extension || extensions=$extensions" "$extension
+		try_install_extension "$extension" || extensions=$extensions" "$extension
 	done
 
 	install_cpptools_extension || extensions=$extensions" ""ms-vscode.cpptools"
 
 	if [ "$extensions" != "" ]; then
-		db_subst maratona-vscode-extensions/question_try_again package $extensions || true
+		db_subst maratona-vscode-extensions/question_try_again package "$extensions" || true
 		db_input high maratona-vscode-extensions/question_try_again || true
 		db_go || true
 		db_get maratona-vscode-extensions/question_try_again || true
 		if [ "$RET" == "Later" ]; then
-			flag=0
+			flag=false
 			db_input high maratona-vscode-extensions/notice || true
 			db_go || true
 			db_get maratona-vscode-extensions/notice
@@ -104,5 +106,5 @@ while $flag ; do
 	fi
 done
 
-rm -rf /usr/share/maratona-vscode-extensions
-mv /opt/vscode-extensions /usr/share/maratona-vscode-extensions
+rm -rf '/usr/share/maratona-vscode-extensions'
+mv '/opt/vscode-extensions' '/usr/share/maratona-vscode-extensions'

--- a/debian/maratona-vscode-extensions.postinst
+++ b/debian/maratona-vscode-extensions.postinst
@@ -18,12 +18,58 @@ try_install_extension() {
 	fi
 }
 
+install_cpptools_extension() {
+	readonly releases_url="https://api.github.com/repos/microsoft/vscode-cpptools/releases/latest"
+	readonly releases_info_file="releases.json"
+	download_url=""
+	readonly package_file="cpptools-linux.vsix"
+
+	echo "Accessing $releases_url"
+
+	# download json
+	if ! wget --tries=3 --timeout=60 --output-document="$releases_info_file" "$releases_url"; then
+		echo "Failed to download releases information for ms-vscode.cpptools"
+		return 2
+	fi
+
+	# check file
+	if [ ! -f "$releases_info_file" ] ; then
+		echo "Failed to read releases information file for ms-vscode.cpptools"
+		return 3
+	fi
+
+	# parse file
+	if ! download_url="$(jq -r '.assets[] | select(.name == "cpptools-linux.vsix") | .browser_download_url' "$releases_info_file")" ; then
+		echo "Failed to read download URL for ms-vscode.cpptools"
+		return 4
+	else
+		rm "$releases_info_file"
+	fi
+
+	echo "Downloading from $download_url"
+
+	# download
+	if ! wget --tries=3 --timeout=60 --continue --output-document="$package_file" "$download_url" ; then
+		echo "Failed to download ms-vscode.cpptools"
+		return 5
+	fi
+
+	# install
+	if ! flatpak run com.visualstudio.code --extensions-dir /opt/vscode-extensions/ --user-data-dir /opt/vscode-extensions/ --install-extension "$package_file" ; then
+		echo "Failed to install ms-vscode.cpptools"
+		return 6
+	fi
+
+	rm "$package_file"
+
+	return 0
+}
+
 flag=true
 while $flag ; do
 	extensions=""
 
 	extensions_list=(
-		ms-vscode.cpptools
 		austin.code-gnu-global
 		formulahendry.code-runner
 		vscjava.vscode-java-debug
@@ -39,6 +85,8 @@ while $flag ; do
 	do
 		try_install_extension $extension || extensions=$extensions" "$extension
 	done
+
+	install_cpptools_extension || extensions=$extensions" ""ms-vscode.cpptools"
 
 	if [ "$extensions" != "" ]; then
 		db_subst maratona-vscode-extensions/question_try_again package $extensions || true


### PR DESCRIPTION
The C and C++ extension downloaded from the online repository required
the installation of downloadable assets in order to work correctly. This
situation would have lead to a broken development environment (only
compilation and execution would be functional while suggestions and 
debugging would be broken) while the competition was in progress, as the 
internet is disabled by a firewall while the contest is being held.

Fixing this issue requires downloading the fully featured offline
version of the `ms-vscode.cpptools` instead of the standard one
available in the official extensions store. The newest release will be
downloaded from the official repository using the Github API, which
required the addition of the packages `jq` and `wget`. No integrity
checks are performed as the official Microsoft repository is believed to
be *trustworthy* and no signature or hash files are available in the
release assets offered.

The previous version of the `maratona-vscode-extensions`' post
installation script used global variables shared by all of its 
functions. This lead to difficult to debug problems and poor
maintainability, so the variables inside the functions were redefined as
local and, whenever possible, as read-only.

Command line arguments were also using variables to store their multiple
dash separated components. Such behaviour also negatively impacted the 
maintainability, as developers would need to correctly place and quote
their commands in other to not fall victim of unexpected shell
expansion. The solution to this problem is specifying all arguments from
commands as arrays. This way ensures that commands may have quoted
arguments and they can be placed without any unobvious restrictions.

Some variables were left unquoted and this may lead in the future to
glitches due to unexpected expansions. This was fixed and double quotes
are now applied to most of the variables. Some strings were also single
quoted to avoid special symbols creating failures difficult to debug.

The changelog was updated to include changes made since the last
modification (commit a8d0a872). This modification also transitions the
package to Ubuntu 20.04 LTS (focal).

- Adds `jq` and `wget` in the `Depends` section of `debian/control`
- Downloads and installs offline version of `ms-vscode.cpptools` from
  the official repository using Github's API.
- Restrict the definition of global variables inside functions
- Use local and read-only variables inside functions whenever possible
- Replace variables that defined command arguments with arrays.
- Double quote variables to avoid unexpected expansions.
- Single quote strings to avoid interferences from special characters.
- Prepares changelog for the new version 20210517