### PR TITLE
Release version 20210517.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+maratona-team-tools (20210517.1) focal; urgency=medium
+
+  * Update maratona-editores-flatpak's description
+
+ -- Davi Antônio da Silva Santos <antoniossdavi@gmail.com>  Mon, 24 May 2021 18:05:34 -0300
+
 maratona-team-tools (20210517) focal; urgency=medium
 
   [ Guilherme Banci ]

--- a/debian/control
+++ b/debian/control
@@ -34,7 +34,7 @@ Architecture: all
 Depends: maratona-flatpak-common
 Recommends: maratona-vscode-extensions
 Description: Pacote contendo a instalação via flatpak dos seguintes editores:
- sublime-text, vscode, pycharm-community, intellij-idea-community, eclipse e clion
+ vscode, pycharm-community, intellij-idea-community e clion
  .
  É um pacote seguro para se instalar em qualquer ambiente Ubuntu e Debian.
 


### PR DESCRIPTION
Removes sublime-text and eclipse from the description of the package
`maratona-editores-flatpak` as they were removed from the installation
process.

The changelog was altered to include changes and the version has been
increased to 20210517.1.

- Updates the description of `maratona-editores-flatpak`
- Bumps version to 20210517.1